### PR TITLE
Add common plugins to babel-parser plugin list

### DIFF
--- a/src/cli.js
+++ b/src/cli.js
@@ -23,9 +23,29 @@ export default options => {
                         sourceType: "module",
 
                         plugins: [
-                            // enable jsx and flow syntax
-                            "jsx",
-                            "flow"
+                            // enable common plugins
+                            "flow", 
+                            "jsx", 
+                            "estree", 
+                            "asyncFunctions", 
+                            "asyncGenerators", 
+                            "classConstructorCall", 
+                            "classProperties", 
+                            "decorators-legacy",
+                            "doExpressions", 
+                            "exponentiationOperator", 
+                            "exportExtensions", 
+                            "functionBind", 
+                            "functionSent", 
+                            "objectRestSpread", 
+                            "trailingFunctionCommas", 
+                            "dynamicImport", 
+                            "numericSeparator", 
+                            "optionalChaining", 
+                            "importMeta", 
+                            "classPrivateProperties", 
+                            "bigInt", 
+                            "optionalCatchBinding",                          
                         ]
                     });
 


### PR DESCRIPTION
Taking a cue from `babel-eslint` to avoid issues like **SyntaxError: This experimental syntax requires enabling the parser plugin: '`XYZ`' (11:19)**
